### PR TITLE
Update devise gem to work with Rails 4.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'jbuilder', '~> 1.2'
 gem 'haml'
 gem 'haml-rails'
 
-gem 'devise'
+gem 'devise', :git => 'https://github.com/plataformatec/devise.git', :branch => 'lm-rails-4-2'
 
 gem 'unicorn'
 gem 'rack-timeout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,19 @@ GIT
     releasetool (0.0.1)
       thor (~> 0.18)
 
+GIT
+  remote: https://github.com/plataformatec/devise.git
+  revision: 1d8890b77372b9c4fd3ec8e9b4963d76774ed33c
+  branch: lm-rails-4-2
+  specs:
+    devise (3.3.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 3.2.6, < 5)
+      responders
+      thread_safe (~> 0.1)
+      warden (~> 1.2.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -54,7 +67,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.6)
     arel (6.0.0)
-    bcrypt (3.1.9)
+    bcrypt (3.1.10)
     bootstrap-sass (3.1.0.2)
       sass (~> 3.2)
     bootstrap-sass-rails (3.1.0.0)
@@ -79,13 +92,6 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     colorize (0.7.5)
-    devise (3.4.1)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
-      responders
-      thread_safe (~> 0.1)
-      warden (~> 1.2.3)
     diff-lcs (1.2.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -215,8 +221,8 @@ GEM
       ffi (>= 0.5.0)
     rdoc (4.2.0)
       json (~> 1.4)
-    responders (2.0.2)
-      railties (>= 4.2.0.alpha, < 5)
+    responders (2.1.0)
+      railties (>= 4.2.0, < 5)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
@@ -293,7 +299,7 @@ DEPENDENCIES
   bootstrap-sass-rails
   capybara (>= 2.2.0)
   coffee-rails (~> 4.0.0)
-  devise
+  devise!
   factory_girl_rails
   faker
   font-awesome-sass


### PR DESCRIPTION
The main devise gem clashes with Rails 4.2.0 causing devise_for
in the routes.rb file to throw errors. For more info see:
http://blog.sailsoftware.co/2014/09/02/fixing-devise-after-rails-4-2-0-beta1-upgrade.html